### PR TITLE
Update dependency Nest 0.4.0

### DIFF
--- a/Sails.podspec
+++ b/Sails.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |spec|
   spec.requires_arc = true
   spec.ios.deployment_target = '8.0'
   spec.osx.deployment_target = '10.9'
-  spec.dependency 'Nest', '~> 0.1.0'
+  spec.dependency 'Nest', '~> 0.4.0'
 end
 


### PR DESCRIPTION
Nest latest release version [0.4.0](https://github.com/nestproject/Nest/releases/tag/0.4.0)